### PR TITLE
Fix ProductsPost to call AddProduct

### DIFF
--- a/Api/ProductsPost.cs
+++ b/Api/ProductsPost.cs
@@ -27,7 +27,7 @@ namespace Api
             var body = await new StreamReader(req.Body).ReadToEndAsync();
             var product = JsonSerializer.Deserialize<Product>(body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-            var newProduct = await productData.UpdateProduct(product);
+            var newProduct = await productData.AddProduct(product);
             return new OkObjectResult(newProduct);
         }
     }


### PR DESCRIPTION
Add doesn't work in the client application because ProductsPost calls UpdateProduct instead of AddProduct for posts. 